### PR TITLE
Initial work on RC checker

### DIFF
--- a/verify_rc.sh
+++ b/verify_rc.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Usage:
+#   ./verify-rc.sh RELEASE_DIRECTORY
+#
+# It is expected that you have md5deep installed on your system.
+# MD5 on OS X 10.9.2 didn't have the ability to verify checksums.
+# You can visit the md5deep website for installation instructions
+# or use Homebrew if you're on OS X.
+#
+# http://md5deep.sourceforge.net/
+#
+# When attempting to import keys for signature verification it is
+# assumed that your release is (at the minimum) distributed as a .zip.
+# If this is not the case, your key file will not be imported. Adjust
+# the extraction code as necessary to accommodate your project's preferred
+# distribution format(s).
+
+echo 
+echo "------------------"
+echo "  Verifying MD5s  "
+echo "------------------"
+for f in $1/*.md5; do
+    echo
+    md5deep -M $f ${f%.md5}
+
+    if [ $? -eq 0 ]; then
+        echo "MD5 verified"
+    else
+        echo "MD5 failed to verify"
+    fi
+done
+
+echo 
+echo "------------------------"
+echo "  Verifying Signatures  "
+echo "------------------------"
+unzip $1/*.zip -d ./test >/dev/null 2>&1
+
+if [ -e ./test/KEYS ]; then
+    echo "Importing KEYS file from release artifact(s)"
+    gpg --import ./test/KEYS
+    echo ""
+fi
+
+for f in $1/*.asc; do
+    echo ""
+    gpg --verify $f
+    echo ""
+done
+rm -rf ./test


### PR DESCRIPTION
Initial work on combining MD5 and signature verification into a single script.

Still needs quite a bit of work. I'm not happy with it needing an external script for MD5 verification but for some reason the default MD5 on 10.9.2 (I think that's what I'm on) can't verify a signature?? (Seriously, am I dumb or something??). GNU md5sum would work as well but that's also not installed by default on 10.9.2. For now, md5deep is easy enough to install (especially with Homebrew) so it should do as a first pass.

The signature verification is a bit brittle with its assumption that every release will be available as a *.zip. Should really check for one of *.zip, *.tgz, *.bzip, etc. and try to import the keys from one of them. Should be a good enough for now though.
