### PR TITLE
Initial script for making an RC

### DIFF
--- a/generate_rc_git.sh
+++ b/generate_rc_git.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Usage: ./generate_rc_git.sh PATH_TO_GIT_REPO TAG_NAME ARTIFACT_DIRECTORY [GPG_KEY_NAME]
+#
+# PATH_TO_GIT_REPO: The path to the git repository that you want to tag a
+#   release candidate in.
+#
+# TAG_NAME: The tag name to use for the release candidate tag.
+#
+# ARTIFACT_DIRECTORY: Directory into which the release candidate artifacts
+#   should be placed.
+#
+# GPG_KEY_NAME (optional): The key name to use when signing the release artifacts
+#   wigh gpg. Check the man pages for the '-u' flag for additional information on
+#   how this will be used.
+
+REPO_PATH=$1
+TAG_NAME=$2
+CUR=`pwd`
+
+cd "$(dirname "$3")"
+ARTIFACT_OUT="$(pwd)/$(basename "$3")"
+cd $CUR
+
+cd $REPO_PATH
+PROJECT=$(git remote -v | grep origin | cut -d '/' -f 2- | cut -d '.' -f 1 | uniq)
+
+git tag -a $TAG_NAME -m "Tagging $TAG_NAME"
+git push --tags
+
+git archive $TAG_NAME | gzip > "$ARTIFACT_OUT/$PROJECT-$TAG_NAME.tgz"
+git archive --format zip --output "$ARTIFACT_OUT/$PROJECT-$TAG_NAME.zip" $TAG_NAME
+
+cd $ARTIFACT_OUT
+md5 "$PROJECT-$TAG_NAME.tgz" > "$PROJECT-$TAG_NAME.tgz.md5"
+md5 "$PROJECT-$TAG_NAME.zip" > "$PROJECT-$TAG_NAME.zip.md5"
+
+if [ -z $4 ]; then
+    gpg --armor --output "$PROJECT-$TAG_NAME.tgz.asc" --detach-sig "$PROJECT-$TAG_NAME.tgz"
+    gpg --armor --output "$PROJECT-$TAG_NAME.zip.asc" --detach-sig "$PROJECT-$TAG_NAME.zip"
+else
+    gpg --armor -u $4 --output "$PROJECT-$TAG_NAME.tgz.asc" --detach-sig "$PROJECT-$TAG_NAME.tgz"
+    gpg --armor -u $4 --output "$PROJECT-$TAG_NAME.zip.asc" --detach-sig "$PROJECT-$TAG_NAME.zip"
+fi


### PR DESCRIPTION
Initial script for building and signing release candidates.

Needs a good bit of love to clean it up and make it more functional.
- Needs to handle parameters in a more sensible manner.
- Needs to allow the user to pass the artifact name instead of mandating that the project name in git be used. This should work for ASF projects but it's not terribly flexible.
- Only a minimal number of release formats are available and there's no way for the user to customize/pick what they want.
- The artifact MD5-ing and signing is done in an extremely naive way that is easily broken if more release formats are added.
