### PR TITLE
Update verify-md5 with better cross platform support

### DIFF
--- a/verify_md5_checksums
+++ b/verify_md5_checksums
@@ -5,20 +5,36 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 
-for file in *.tar.gz *.bz2 *.zip *.tgz
- do 
-   md5sum $file >> allmd5s.txt
+MD5S="allmd5s.txt"
+VERIFY=""
+if type md5deep &>/dev/null; then
+    echo
+    echo "** NOTE ** Using md5deep with -M ..."
+    echo "The files that match a known MD5 will be displayed."
+    echo "If you don't see an RC artifact something is wrong with the MD5"
+    echo
+
+    VERIFY="md5deep -M $MD5S *"
+elif type md5sum &>/dev/null; then
+    VERIFY="md5sum -c $MD5S"
+else
+    echo "You don't have an adequate MD5 application. Please install md5sum or md5deep"
+fi
+
+echo "Verifying MD5s ..."
+for f in *.md5; do
+   cat $f >> $MD5S
 done
 
-md5sum -c allmd5s.txt 
-rm -rf allmd5s.txt
+eval $VERIFY
+rm -rf $MD5S


### PR DESCRIPTION
- verify_md5_checksums now checks the user's system for a usable md5 application instead of defaulting to md5sum. This helps to address the issue with OS X 10.9.x not having md5sum installed by default.
- When given a choice between md5sum and md5deep we prefer md5deep. md5sum seems to have issues verifying md5deep outputs whereas the other way around is not a problem.
